### PR TITLE
位置調整

### DIFF
--- a/src/components/StarItem.tsx
+++ b/src/components/StarItem.tsx
@@ -36,7 +36,7 @@ const StarList: React.FC<Props> = props => {
   const UserIcon = styled.img`
     border-radius: 10px;
     height: 30px;
-    margin-right: 15px;
+    margin: 5px;
     text-align: center;
     width: 30px;
     vertical-align: middle;
@@ -68,20 +68,22 @@ const StarList: React.FC<Props> = props => {
   `;
 
   const ListLayout = styled(ListComponent)`
-    margin-top: 10px;
-    margin-right: 20px;
-    margin-bottom: 10px;
-    margin-left: 20px;
+    margin-top: 14px;
+    margin-right: 10px;
+    margin-bottom: 14px;
+    margin-left: 10px;
     padding: 15px;
-    width: 29%;
+    width: 22%;
   `;
 
   const ListDetails = styled.details`
-    width: 20%;
+    width: 10%;
     position: relative;
     z-index: 2;
     display: flex;
     cursor: pointer;
+    font-size: 10px;
+    float: right;
   `;
 
   const ListHeader = styled.h2`
@@ -92,56 +94,62 @@ const StarList: React.FC<Props> = props => {
   const ListTitle = styled.a`
     text-decoration: inherit;
     text-align: center;
-    position: absolute;
+    position: relative;
   `;
 
   const ListLanguage = styled.span`
     background: #ddd;
+    font-size: 14px;
     border-radius: 3px;
     border: 1px solid #aaa;
     padding: 3px;
+    margin: 10px;
   `;
 
   const ListMemo = styled.span`
     background: #fff;
     border-bottom: 1px solid #aaa;
+    margin-left: 10px;
   `;
 
   const CommentSummary = styled.summary`
     position: relative;
     z-index: 2;
     padding: 0.5em;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
   `;
 
   return (
     <ListLayout>
-      <ListDetails>
-        <CommentSummary>...</CommentSummary>
-        <input
-          type="button"
-          value="コメント更新"
-          onClick={e => {
-            openDisplay(display);
-          }}
-        />
-        <DeleteButton
-          onClick={() => {
-            deleteRepository();
-          }}
-        >
-          消去
-        </DeleteButton>
-      </ListDetails>
       <ListHeader>
         <UserIcon src={props.stars.ownerIcon} />
         <ListTitle href={props.stars.url}>{props.stars.name}</ListTitle>
+        <ListLanguage>{props.stars.primaryLanguage}</ListLanguage>
+        <ListDetails>
+          <CommentSummary>...</CommentSummary>
+          <input
+            type="button"
+            value="コメント更新"
+            onClick={e => {
+              openDisplay(display);
+            }}
+          />
+          <DeleteButton
+            onClick={() => {
+              deleteRepository();
+            }}
+          >
+            消去
+          </DeleteButton>
+        </ListDetails>
       </ListHeader>
       <div>
-        primaryLanguage：
-        <ListLanguage>{props.stars.primaryLanguage}</ListLanguage>
+        <em>Memo</em>
       </div>
       <div>
-        Memo：
         {display ? (
           <ListMemo>{props.stars.comment}</ListMemo>
         ) : (

--- a/src/components/StarList.tsx
+++ b/src/components/StarList.tsx
@@ -118,8 +118,11 @@ const Stars: React.FC<Props> = props => {
     padding: 5px;
   `;
 
+  const Interval = styled.span`
+    margin: 10px;
+  `;
+
   const UserName = styled.div`
-    margin: 15px;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -157,6 +160,7 @@ const Stars: React.FC<Props> = props => {
 
   const SortTag = styled.div`
     padding: 5px;
+    margin-left: 15px;
   `;
 
   const SelectForm = styled.select`
@@ -172,19 +176,25 @@ const Stars: React.FC<Props> = props => {
     height: auto;
   `;
 
+  const PeageTop = styled.a`
+    float: right;
+    margin: 15px;
+  `;
+
   return (
     <div>
       <Header>
         お気に入り一覧
         <UserName>
-          <UserIcon src={userData.avatarUrl} /> by{' '}
+          <UserIcon src={userData.avatarUrl} />
+          <Interval>by</Interval>
           <a href={userData.url}>{userData.login}</a>
           <LoginButton>新規リポジトリー登録</LoginButton>
           <LogoutButton>ログアウト</LogoutButton>
         </UserName>
       </Header>
       <SortTag>
-        PrimaryLanguage:
+        主要言語:
         <SelectForm
           name="PrimaryLanguage"
           onChange={e => {
@@ -196,7 +206,7 @@ const Stars: React.FC<Props> = props => {
             return <option value={item}>{item}</option>;
           })}
         </SelectForm>
-        sort:
+        タイトル並べ替え:
         <SelectForm
           name="リポジトリ名"
           onChange={e => {
@@ -222,7 +232,7 @@ const Stars: React.FC<Props> = props => {
         })}
       </ListBack>
       <div>
-        <a href="#">▲　ページトップへ</a>
+        <PeageTop href="#">▲　ページトップへ</PeageTop>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要
お気に入り一覧ページパーツ位置調整

## Issue
Closes #9 

## 修正内容（箇条書きで）
・ヘッダーの間隔を調整
・フィルタ機能の間隔を調整
・リストのアイコンのマージンを調整
・タイトル、主要言語、メニュー用の三点リーダーを同列に配置（メニューは右寄せ）
・リストを一列で４つ並べられるように変更
・ページトップへのリンクを画面右寄りに変更

## 気になることなどあれば
・リストを一列４つ並べにした場合、主要言語がjavascriptのように長いものだった場合、リポジトリ名を結構短くせざるを得ない為、要素の位置か一列に並べる数を検討すべきか
・ソート機能のセレクタ内の降順の表記が下よりになっているが直しかたが不明・・・

注：リポジトリ名の長さを調整するフォーマッタの実装、三点リーダーのデザイン及びメニューリスト実装は別ブランチで作業をする
