### PR TITLE
タイトルフォーマット機能実装

### DIFF
--- a/src/components/StarItem.tsx
+++ b/src/components/StarItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import UpdataComment from '../external/UpdataComment';
-import ListTitleFormatter from '../util/ListTitleFormatter';
+import { listTitleFormatter } from '../util/ListTitleFormatter';
 import StarDataRes from '../../data/StarDataRes';
 
 type Props = {
@@ -136,7 +136,7 @@ const StarList: React.FC<Props> = props => {
       <ListHeader>
         <UserIcon src={props.stars.ownerIcon} />
         <ListTitle href={props.stars.url}>
-          {ListTitleFormatter(props.stars.name)}
+          {listTitleFormatter(props.stars.name)}
         </ListTitle>
         <ListLanguage>{props.stars.primaryLanguage}</ListLanguage>
         <ListDetails>

--- a/src/components/StarItem.tsx
+++ b/src/components/StarItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import UpdataComment from '../external/UpdataComment';
+import ListTitleFormatter from '../util/ListTitleFormatter';
 import StarDataRes from '../../data/StarDataRes';
 
 type Props = {
@@ -134,7 +135,9 @@ const StarList: React.FC<Props> = props => {
     <ListLayout>
       <ListHeader>
         <UserIcon src={props.stars.ownerIcon} />
-        <ListTitle href={props.stars.url}>{props.stars.name}</ListTitle>
+        <ListTitle href={props.stars.url}>
+          {ListTitleFormatter(props.stars.name)}
+        </ListTitle>
         <ListLanguage>{props.stars.primaryLanguage}</ListLanguage>
         <ListDetails>
           <CommentSummary>...</CommentSummary>

--- a/src/util/ListTitleFormatter.ts
+++ b/src/util/ListTitleFormatter.ts
@@ -1,5 +1,3 @@
-const listTitleFormatter = (listTitle: String) => {
+export const listTitleFormatter = (listTitle: String) => {
   return listTitle.length > 17 ? listTitle.substr(0, 17) + '...' : listTitle;
 };
-
-export default listTitleFormatter;

--- a/src/util/ListTitleFormatter.ts
+++ b/src/util/ListTitleFormatter.ts
@@ -1,0 +1,5 @@
+const listTitleFormatter = (listTitle: String) => {
+  return listTitle.length > 17 ? listTitle.substr(0, 17) + '...' : listTitle;
+};
+
+export default listTitleFormatter;


### PR DESCRIPTION
## 概要
リポジトリ名をリスト内に治める為にリポジトリ名を整形する機能を実装

## Issue
Closes #10 
<!-- Closes #XXX でチケットを閉じれる -->

## 修正内容（箇条書きで）
・リストの横幅に収まる文字数(17文字)に整形する機能を実装
・リストのタイトルを上記関数を呼び出し表示

## 気になることなどあれば
